### PR TITLE
fix missing slash in urls

### DIFF
--- a/frontend/src/views/Resources.vue
+++ b/frontend/src/views/Resources.vue
@@ -21,7 +21,7 @@
           class="project-item">
           <a 
             v-if="!project.featured"
-            :href="'https://github.com' + project.title" 
+            :href="'https://github.com/' + project.title" 
             class="link-external list-link">
             <v-icon 
               small 


### PR DESCRIPTION
Fixing a missing slash in links on resource page