### PR TITLE
Fix navigation item spacing on small viewports

### DIFF
--- a/frontend/src/components/TheNavigation.vue
+++ b/frontend/src/components/TheNavigation.vue
@@ -47,6 +47,8 @@
       font-weight: 500
       text-decoration: none
       font-size: 1rem
+      :first-child
+        margin-left: 0
       @media screen and (max-width: 320px)
         margin-left: .5rem
 


### PR DESCRIPTION
Because margin-left is applied to all links the logo is not displayed properly on small viewports. By removing the obsolete margin-left for the first entry spacing is better and the logo is displayed correctly on small screens.

**before:**
![image](https://user-images.githubusercontent.com/3203968/46886110-2badf780-ce5a-11e8-884a-d55bc4e2283e.png)

**after:**
![image](https://user-images.githubusercontent.com/3203968/46886115-310b4200-ce5a-11e8-8fdf-105e2a3d00fd.png)

