### PR TITLE
FIX: Not to include self-PR

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -121,7 +121,8 @@ router.get('/data', async (req, res, next) => {
                 obj.type === 'PullRequestEvent' &&
                 obj.payload.action === 'opened' &&
                 new Date(obj.payload.pull_request.created_at) >
-                  new Date('2018-10-01')
+                  new Date('2018-10-01') &&
+                !obj.repo.name.match(new RegExp(`^${users[i].login}\/.*`)) 
               ) {
                 prsPerUser[users[i].login] = {
                   latestPr:


### PR DESCRIPTION
Currently the leaderboard includes PRs the users made to their own repositories. These should not be counted in.