### PR TITLE
Pull requests load refactoring

### DIFF
--- a/util/helpers.js
+++ b/util/helpers.js
@@ -8,8 +8,8 @@ const afterPush = err => {
   }
 };
 
-const paginate = async (octokit, method, username) => {
-  let response = await method({ per_page: 100, username });
+const paginate = async (octokit, method, parameters) => {
+  let response = await method({ ...parameters, per_page: 100, page: 1 });
   let { data } = response;
   while (octokit.hasNextPage(response)) {
     response = await octokit.getNextPage(response);


### PR DESCRIPTION
I have faced the problem with loading pull requests using events endpoint.

Github API is able to get only the first three pages of events, on the fourth page it is returning:
* https://api.github.com/users/USERLOGIN/events?access_token=YOURACCESSKEY&per_page=100&page=4
```
  "message": "In order to keep the API fast for everyone, pagination is limited for this resource. Check the rel=last link relation in the Link response header to see how far back you can traverse.",
```

So what happened in my fork is that some of the pull requests were not returned and not counted.

I have rewrite paginate method to be universal and used search endpoint for loading the requests.
It also filters out the pull requests labeled as invalid (as Hacktoberfest do).

I don't insist on merging, but I think that is a good way how to submit the potential bug.